### PR TITLE
Generate a `.signature.manifest`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "archiver": "^7.0.1",
     "commander": "^10.0.1",
     "node-fetch": "2.6.12",
-    "unzipper": "^0.11.6"
+    "unzipper": "^0.11.6",
+    "yauzl": "^3.1.3"
   },
   "devDependencies": {
     "@types/archiver": "^6.0.2",
@@ -58,6 +59,7 @@
     "@types/node": "^14.0.0",
     "@types/node-fetch": "^2.6.2",
     "@types/unzipper": "^0.10.9",
+    "@types/yauzl": "^2.10.3",
     "@typescript-eslint/eslint-plugin": "^5.52.0",
     "@typescript-eslint/parser": "^5.52.0",
     "eslint": "^8.28.0",

--- a/src/utils/__snapshots__/signature-manifest.test.ts.snap
+++ b/src/utils/__snapshots__/signature-manifest.test.ts.snap
@@ -1,0 +1,62 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`signatureManifestTest be able to generate a signature manifest file 1`] = `
+{
+  "entries": {
+    "W2NvbnRlbnRfdHlwZXNdLnhtbA==": {
+      "digests": {
+        "sha256": "9320e1ab24aa3ce67af21fb9c59035a59a860752570ff02407c664a5b675027a",
+      },
+      "size": 462,
+    },
+    "ZXh0ZW5zaW9uL291dC9leHRlbnNpb24uanM=": {
+      "digests": {
+        "sha256": "1af5c4728d2422b0da6e3e79303c1d31bbcf22655233669a37f697ea739cac30",
+      },
+      "size": 535393,
+    },
+    "ZXh0ZW5zaW9uL2NoYW5nZWxvZy5tZA==": {
+      "digests": {
+        "sha256": "353ea85b16931f8fe064f3c89088cf24a0e57ec2db37a93506545d40f8525347",
+      },
+      "size": 277,
+    },
+    "ZXh0ZW5zaW9uL2xpY2Vuc2UudHh0": {
+      "digests": {
+        "sha256": "a5e6ddb3af783a02eacc848cbe309cc0940b4859ac653e9b1a2e21a4fea22552",
+      },
+      "size": 1056,
+    },
+    "ZXh0ZW5zaW9uL3BhY2thZ2UuanNvbg==": {
+      "digests": {
+        "sha256": "8244c0d61d31395969b111043ed842edda56f621a3419d49e3e097dba676428e",
+      },
+      "size": 10829,
+    },
+    "ZXh0ZW5zaW9uL3JlYWRtZS5tZA==": {
+      "digests": {
+        "sha256": "639a6272fcd5d082485afa3608dabc23eab7a0040c764de92c668d7666ca5f20",
+      },
+      "size": 1014,
+    },
+    "ZXh0ZW5zaW9uL3Jlc291cmNlcy9pY29uLnBuZw==": {
+      "digests": {
+        "sha256": "7dda10c951ece86295688e6126904a8f177b0b5068979b02db7ae64f71231305",
+      },
+      "size": 17422,
+    },
+    "ZXh0ZW5zaW9uLnZzaXhtYW5pZmVzdA==": {
+      "digests": {
+        "sha256": "04723002cd34ea52ed00181dec4278a88d9eed2eb219b1735d8be52fffa7b7c5",
+      },
+      "size": 2681,
+    },
+  },
+  "package": {
+    "digests": {
+      "sha256": "3e45182da389bf4748decec32587315d89732e7cfa371a4bbff105616afc6e86",
+    },
+    "size": 173087,
+  },
+}
+`;

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -7,6 +7,7 @@ import { verifySignature } from "./verify";
 import * as crypto from "crypto";
 import { getExtensionMeta } from "./getExtensionMeta";
 import { extractFileAsBufferUsingStreams, zipBuffers } from "./zip";
+import { generateSignatureManifest } from "./signature-manifest";
 
 /**
  * Sign an extension package. The signature is saved to `extension.sigzip`
@@ -25,9 +26,11 @@ export const sign = async (
     const outputPath = options?.output ?? `./${SIGNED_ARCHIVE_NAME}`;
 
     const signature = await signFile(extensionFile, privateKey);
+    const signatureManifest = await generateSignatureManifest(vsixFilePath);
 
     const files = [
         { filename: SIGNATURE_FILE_NAME, buffer: signature },
+        { filename: ".signature.manifest", buffer: Buffer.from(JSON.stringify(signatureManifest)) },
         // We leave the p7s file empty because VS Code expects it to be present
         // https://github.com/microsoft/vscode/blob/0ead1f80c9e0d6ea0732c40faea3095c6f7f165a/src/vs/platform/extensionManagement/node/extensionDownloader.ts#L157
         { filename: ".signature.p7s", buffer: Buffer.alloc(0) },

--- a/src/utils/signature-manifest.test.ts
+++ b/src/utils/signature-manifest.test.ts
@@ -1,0 +1,19 @@
+import { download } from "./download";
+import { unlink } from "fs/promises";
+import { generateSignatureManifest } from "./signature-manifest";
+
+jest.setTimeout(20_000);
+
+describe("signatureManifestTest", () => {
+    test("be able to generate a signature manifest file", async () => {
+        const extensionDestination = await download(
+            "https://open-vsx.org/api/jeanp413/open-remote-ssh/0.0.33/file/jeanp413.open-remote-ssh-0.0.33.vsix",
+            {},
+        );
+        expect(await generateSignatureManifest(extensionDestination)).toMatchSnapshot();
+
+        // Clean up
+        await unlink(extensionDestination);
+        console.log(`Deleted ${extensionDestination}`);
+    });
+});

--- a/src/utils/signature-manifest.ts
+++ b/src/utils/signature-manifest.ts
@@ -1,0 +1,65 @@
+import { readZip } from "@vscode/vsce/out/zip";
+import { createHash } from "node:crypto";
+import * as fs from "node:fs/promises";
+
+type VsixSignatureManifest = {
+    package: {
+        size: number;
+        digests: {
+            sha256: string;
+        };
+    };
+    entries: {
+        [key: string]: {
+            size: number;
+            digests: {
+                sha256: string;
+            };
+        };
+    };
+};
+
+/**
+ * @returns a sha256 hash of the file
+ */
+const fileSha256 = async (file: Buffer): Promise<string> => {
+    return new Promise((resolve, reject) => {
+        try {
+            const hash = createHash("sha256");
+            hash.update(file);
+            const digest = hash.digest("hex");
+            resolve(digest);
+        } catch (error) {
+            reject(error);
+        }
+    });
+};
+
+const toBase64 = (string: string): string => Buffer.from(string).toString("base64");
+
+export const generateSignatureManifest = async (vsixFilePath: string): Promise<VsixSignatureManifest> => {
+    const extensionPackage = await fs.readFile(vsixFilePath);
+    const extensionPackageContentsDetails: Map<string, Buffer> = await readZip(vsixFilePath, (entry) => true);
+
+    const entries: VsixSignatureManifest["entries"] = {};
+    for (const [entryPath, entryContent] of extensionPackageContentsDetails.entries()) {
+        const entrySize = entryContent.length;
+        const entrySha256 = await fileSha256(entryContent);
+        entries[toBase64(entryPath)] = {
+            size: entrySize,
+            digests: {
+                sha256: entrySha256,
+            },
+        };
+    }
+
+    return {
+        package: {
+            size: extensionPackage.length,
+            digests: {
+                sha256: await fileSha256(extensionPackage),
+            },
+        },
+        entries,
+    };
+};

--- a/src/utils/signature-manifest.ts
+++ b/src/utils/signature-manifest.ts
@@ -1,6 +1,6 @@
-import { readZip } from "@vscode/vsce/out/zip";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
+import { readZip } from "./zip";
 
 type VsixSignatureManifest = {
     package: {
@@ -20,14 +20,14 @@ type VsixSignatureManifest = {
 };
 
 /**
- * @returns a sha256 hash of the file
+ * @returns a sha256 hash of the file in base64
  */
 const fileSha256 = async (file: Buffer): Promise<string> => {
     return new Promise((resolve, reject) => {
         try {
             const hash = createHash("sha256");
             hash.update(file);
-            const digest = hash.digest("hex");
+            const digest = hash.digest("base64");
             resolve(digest);
         } catch (error) {
             reject(error);
@@ -39,7 +39,7 @@ const toBase64 = (string: string): string => Buffer.from(string).toString("base6
 
 export const generateSignatureManifest = async (vsixFilePath: string): Promise<VsixSignatureManifest> => {
     const extensionPackage = await fs.readFile(vsixFilePath);
-    const extensionPackageContentsDetails: Map<string, Buffer> = await readZip(vsixFilePath, (entry) => true);
+    const extensionPackageContentsDetails: Map<string, Buffer> = await readZip(vsixFilePath);
 
     const entries: VsixSignatureManifest["entries"] = {};
     for (const [entryPath, entryContent] of extensionPackageContentsDetails.entries()) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
         "noUnusedLocals": true,
         "strictNullChecks": true,
         "outDir": "lib",
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "esModuleInterop": true,
     },
     "include": ["src"],
     "exclude": ["**/*.spec.ts", "**/*.spec.tsx", "**/node_modules/**/*"]

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,6 +893,13 @@
   dependencies:
     "@types/yargs-parser" "*"
 
+"@types/yauzl@^2.10.3":
+  version "2.10.3"
+  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.3.tgz#e9b2808b4f109504a03cda958259876f61017999"
+  integrity sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==
+  dependencies:
+    "@types/node" "*"
+
 "@typescript-eslint/eslint-plugin@^5.52.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz#aeef0328d172b9e37d9bab6dbc13b87ed88977db"
@@ -1710,9 +1717,9 @@ ecdsa-sig-formatter@1.0.11:
     safe-buffer "^5.0.1"
 
 electron-to-chromium@^1.4.668:
-  version "1.4.786"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.786.tgz#974d7eeac61c5ffa285dc55555d06b97b05f6831"
-  integrity sha512-i/A2UB0sxYViMN0M2zIotQFRIOt1jLuVXudACHBDiJ5gGuAUzf/crZxwlBTdA0O52Hy4CNtTzS7AKRAacs/08Q==
+  version "1.4.787"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.787.tgz#3eedd0a3b8be2b9e96e21675d399786ad90b99ed"
+  integrity sha512-d0EFmtLPjctczO3LogReyM2pbBiiZbnsKnGF+cdZhsYzHm/A0GV7W94kqzLD8SN4O3f3iHlgLUChqghgyznvCQ==
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -1944,7 +1951,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-fifo@^1.1.0, fast-fifo@^1.2.0:
+fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
@@ -3229,9 +3236,9 @@ natural-compare@^1.4.0:
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
 node-abi@^3.3.0:
-  version "3.62.0"
-  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.62.0.tgz#017958ed120f89a3a14a7253da810f5d724e3f36"
-  integrity sha512-CPMcGa+y33xuL1E0TcNIu4YyaZCxnnvkVaEXrsosR3FxN+fV8xvb7Mzpb7IgKler10qeMkE6+Dp8qJhpzdq35g==
+  version "3.63.0"
+  resolved "https://registry.yarnpkg.com/node-abi/-/node-abi-3.63.0.tgz#9bfbe68b87357f8b508554608b323e9b1052d045"
+  integrity sha512-vAszCsOUrUxjGAmdnM/pq7gUgie0IRteCQMX6d4A534fQCR93EJU5qgzBvU6EkFfK27s0T3HEV3BOyJIr7OMYw==
   dependencies:
     semver "^7.3.5"
 
@@ -3798,12 +3805,13 @@ stoppable@^1.1.0:
   integrity sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==
 
 streamx@^2.15.0:
-  version "2.16.1"
-  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.16.1.tgz#2b311bd34832f08aa6bb4d6a80297c9caef89614"
-  integrity sha512-m9QYj6WygWyWa3H1YY69amr4nVgy61xfjys7xO7kviL5rfIEc2naf+ewFiOA+aEJD7y0JO3h2GoiUv4TDwEGzQ==
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/streamx/-/streamx-2.18.0.tgz#5bc1a51eb412a667ebfdcd4e6cf6a6fc65721ac7"
+  integrity sha512-LLUC1TWdjVdn1weXGcSxyTR3T4+acB6tVGXT95y0nGbca4t4o/ng1wKAGTljm9VicuCVLvRlqFYXYy5GwgM7sQ==
   dependencies:
-    fast-fifo "^1.1.0"
+    fast-fifo "^1.3.2"
     queue-tick "^1.0.1"
+    text-decoder "^1.1.0"
   optionalDependencies:
     bare-events "^2.2.0"
 
@@ -3815,7 +3823,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3847,7 +3864,14 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -3945,6 +3969,13 @@ test-exclude@^6.0.0:
     "@istanbuljs/schema" "^0.1.2"
     glob "^7.1.4"
     minimatch "^3.0.4"
+
+text-decoder@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/text-decoder/-/text-decoder-1.1.0.tgz#3379e728fcf4d3893ec1aea35e8c2cac215ef190"
+  integrity sha512-TmLJNj6UgX8xcUZo4UDStGQtDiTzF7BzWlzn9g7UWrjkpHr5uJTK1ld16wZ3LXb2vb6jH8qU89dW5whuMdXYdw==
+  dependencies:
+    b4a "^1.6.4"
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -4154,7 +4185,16 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -4238,6 +4278,14 @@ yauzl@^2.3.1:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yauzl@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-3.1.3.tgz#f61c17ad1a09403bc7adb01dfb302a9e74bf4a50"
+  integrity sha512-JCCdmlJJWv7L0q/KylOekyRaUrdEoUxWkWVcgorosTROCFWiS9p2NNPE9Yb91ak7b1N5SxAZEliWpspbZccivw==
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    pend "~1.2.0"
 
 yazl@^2.2.2:
   version "2.5.1"


### PR DESCRIPTION
Generates a signature manifest with all the contents of a `vsix` along with each file's digest. At this time, no validation against the manifest is done, only generation.

It's JP's suggestion from https://github.com/filiptronicek/node-ovsx-sign/pull/16#issuecomment-2138302159.

## How to test

```
node lib/node-ovsx-sign key-pair
node lib/node-ovsx-sign sign some-extension.vsix private.pem
```

